### PR TITLE
Allow overriding and validating cms signature algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Next release
 
-*Currently empty*
+* Made verification of signatures extendable
+* Made signature hash algorithm configurable
 
 ## 0.9.2
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Conformance is claimed according to 7.2.1 (TBA) and 7.2.2 in
 <dependency>
 	<groupId>no.difi.commons</groupId>
 	<artifactId>commons-asic</artifactId>
-	<version>0.9.2</version>
+	<version>0.9.3</version>
 </dependency>
 ```
 

--- a/src/main/java/no/difi/asic/AbstractAsicReader.java
+++ b/src/main/java/no/difi/asic/AbstractAsicReader.java
@@ -37,6 +37,8 @@ abstract class AbstractAsicReader implements Closeable {
     // Initiated with 'true' as the first file should not do anything.
     private boolean contentIsWritten = true;
 
+    private SignatureVerifier signatureVerifier = new SignatureVerifier();
+
     /**
      * Used to hold signature or manifest for CAdES as they are not in the same file.
      */
@@ -164,7 +166,7 @@ abstract class AbstractAsicReader implements Closeable {
             byte[] data = o instanceof String ? ((String) o).getBytes() : ((String) signingContent.get(sigReference)).getBytes();
             byte[] sign = o instanceof ByteArrayOutputStream ? ((ByteArrayOutputStream) o).toByteArray() : ((ByteArrayOutputStream) signingContent.get(sigReference)).toByteArray();
 
-            Certificate certificate = SignatureVerifier.validate(data, sign);
+            Certificate certificate = signatureVerifier.validate(data, sign);
             certificate.setCert(currentZipEntry.getName());
             manifestVerifier.addCertificate(certificate);
 
@@ -190,4 +192,7 @@ abstract class AbstractAsicReader implements Closeable {
         return manifest;
     }
 
+    public void setSignatureVerifier(SignatureVerifier verifier) {
+        this.signatureVerifier = verifier;
+    }
 }

--- a/src/main/java/no/difi/asic/AsicReaderFactory.java
+++ b/src/main/java/no/difi/asic/AsicReaderFactory.java
@@ -16,14 +16,24 @@ public class AsicReaderFactory {
         return newFactory(signatureMethod.getMessageDigestAlgorithm());
     }
 
+    public static AsicReaderFactory newFactory(SignatureMethod signatureMethod, SignatureVerifier signatureVerifier) {
+        return new AsicReaderFactory(signatureMethod.getMessageDigestAlgorithm(), signatureVerifier);
+    }
+
     static AsicReaderFactory newFactory(MessageDigestAlgorithm messageDigestAlgorithm) {
         return new AsicReaderFactory(messageDigestAlgorithm);
     }
 
     private MessageDigestAlgorithm messageDigestAlgorithm;
+    private SignatureVerifier signatureVerifier = null;
 
     private AsicReaderFactory(MessageDigestAlgorithm messageDigestAlgorithm) {
         this.messageDigestAlgorithm = messageDigestAlgorithm;
+    }
+
+    public AsicReaderFactory(MessageDigestAlgorithm messageDigestAlgorithm, SignatureVerifier signatureVerifier) {
+        this.messageDigestAlgorithm = messageDigestAlgorithm;
+        this.signatureVerifier = signatureVerifier;
     }
 
     public AsicReader open(File file) throws IOException {
@@ -35,6 +45,10 @@ public class AsicReaderFactory {
     }
 
     public AsicReader open(InputStream inputStream) throws IOException {
-        return new AsicReaderImpl(messageDigestAlgorithm, inputStream);
+        AsicReaderImpl reader = new AsicReaderImpl(messageDigestAlgorithm, inputStream);
+        if(signatureVerifier != null) {
+            reader.setSignatureVerifier(signatureVerifier);
+        }
+        return reader;
     }
 }


### PR DESCRIPTION
Hi
ETSI standards are not my strong side, but I'd like to be able to specify different cms signature algorithm (e.g. sha-256), since the default appears to be sha-1. I'd also like to be able to soft-fail or hard-fail on receiving asic files with sha-1 pkcs#7 signatures.