### PR TITLE
Add support for certificate chain in the signature.

### DIFF
--- a/src/main/java/no/difi/asic/SignatureHelper.java
+++ b/src/main/java/no/difi/asic/SignatureHelper.java
@@ -11,7 +11,7 @@ import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
-import java.util.Collections;
+import java.util.Arrays;
 
 import org.bouncycastle.cert.jcajce.JcaCertStore;
 import org.bouncycastle.cms.CMSProcessableByteArray;
@@ -184,7 +184,7 @@ public class SignatureHelper {
 
             CMSSignedDataGenerator cmsSignedDataGenerator = new CMSSignedDataGenerator();
             cmsSignedDataGenerator.addSignerInfoGenerator(signerInfoGenerator);
-            cmsSignedDataGenerator.addCertificates(new JcaCertStore(Collections.singletonList(x509Certificate)));
+            cmsSignedDataGenerator.addCertificates(new JcaCertStore(Arrays.asList(certificateChain)));
             CMSSignedData cmsSignedData = cmsSignedDataGenerator.generate(new CMSProcessableByteArray(data), false);
 
             logger.debug(BaseEncoding.base64().encode(cmsSignedData.getEncoded()));


### PR DESCRIPTION
Currently, the signature only contains the signing certificate, without its certificate chain. This poses some challenges for the validation of the signature by actors that cannot trust the signing certificate itself and rely on the full chain for proper validation. This change does not impact the case in which there is no certificate chain, as the signing certificate is then the only certificate in the chain added to the signature. 