### PR TITLE
Add support for extracting the certificate chain from the signature 

### DIFF
--- a/src/main/java/no/difi/asic/AsicReader.java
+++ b/src/main/java/no/difi/asic/AsicReader.java
@@ -1,9 +1,11 @@
 package no.difi.asic;
 
 import no.difi.commons.asic.jaxb.asic.AsicManifest;
+import no.difi.commons.asic.jaxb.asic.Certificate;
 
 import java.io.*;
 import java.nio.file.Path;
+import java.util.List;
 
 public interface AsicReader extends Closeable {
 
@@ -47,4 +49,6 @@ public interface AsicReader extends Closeable {
     InputStream inputStream() throws IOException;
 
     AsicManifest getAsicManifest();
+
+    List<Certificate> getCertificateChain();
 }

--- a/src/main/java/no/difi/asic/SignatureVerifier.java
+++ b/src/main/java/no/difi/asic/SignatureVerifier.java
@@ -1,6 +1,7 @@
 package no.difi.asic;
 
 import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cms.CMSProcessableByteArray;
 import org.bouncycastle.cms.CMSSignedData;
 import org.bouncycastle.cms.SignerInformation;
@@ -10,6 +11,11 @@ import org.bouncycastle.util.Store;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 /**
  * @author erlend
  */
@@ -17,36 +23,60 @@ public class SignatureVerifier {
 
     private static final Logger logger = LoggerFactory.getLogger(SignatureHelper.class);
 
-    private static JcaSimpleSignerInfoVerifierBuilder jcaSimpleSignerInfoVerifierBuilder =
+    private static final JcaSimpleSignerInfoVerifierBuilder jcaSimpleSignerInfoVerifierBuilder =
             new JcaSimpleSignerInfoVerifierBuilder().setProvider(BCHelper.getProvider());
 
     @SuppressWarnings("unchecked")
-    public static no.difi.commons.asic.jaxb.asic.Certificate validate(byte[] data, byte[] signature) {
-        no.difi.commons.asic.jaxb.asic.Certificate certificate = null;
+    public static List<no.difi.commons.asic.jaxb.asic.Certificate> validate(byte[] data, byte[] signature) {
+        List<X509Certificate> x509CertificateChain = new ArrayList<>();
+        List<no.difi.commons.asic.jaxb.asic.Certificate> certificateChain = new ArrayList<>();
+        no.difi.commons.asic.jaxb.asic.Certificate signerCertificate = null;
 
         try {
             CMSSignedData cmsSignedData = new CMSSignedData(new CMSProcessableByteArray(data), signature);
             Store store = cmsSignedData.getCertificates();
             SignerInformationStore signerInformationStore = cmsSignedData.getSignerInfos();
 
+            // Extract and verify the signing certificate
             for (SignerInformation signerInformation : signerInformationStore.getSigners()) {
                 X509CertificateHolder x509Certificate = (X509CertificateHolder) store.getMatches(signerInformation.getSID()).iterator().next();
                 logger.info(x509Certificate.getSubject().toString());
 
                 if (signerInformation.verify(jcaSimpleSignerInfoVerifierBuilder.build(x509Certificate))) {
-                    certificate = new no.difi.commons.asic.jaxb.asic.Certificate();
-                    certificate.setCertificate(x509Certificate.getEncoded());
-                    certificate.setSubject(x509Certificate.getSubject().toString());
+                    x509CertificateChain.add(new JcaX509CertificateConverter().getCertificate(x509Certificate));
+                    signerCertificate = new no.difi.commons.asic.jaxb.asic.Certificate();
+                    signerCertificate.setCertificate(x509Certificate.getEncoded());
+                    signerCertificate.setSubject(x509Certificate.getSubject().toString());
+                    certificateChain.add(signerCertificate);
+                    break; //Since a single signer is assumed throughout this program, break when one is found
+                }
+            }
+
+            // Build the certificate chain, verifying the issuer's signature for each certificate in the chain
+            Collection<X509CertificateHolder> allCerts = store.getMatches(null);
+            for(int i =0; i<allCerts.size()-1; i++){
+                for (X509CertificateHolder holder : allCerts){
+                    X509Certificate lastCert = x509CertificateChain.get(x509CertificateChain.size()-1);
+                    X509Certificate issuer = new JcaX509CertificateConverter().getCertificate(holder);
+                    if(issuer.getSubjectDN().equals(lastCert.getIssuerDN())){
+                        lastCert.verify(issuer.getPublicKey());
+                        x509CertificateChain.add(issuer);
+                        no.difi.commons.asic.jaxb.asic.Certificate issuerCertificate = new no.difi.commons.asic.jaxb.asic.Certificate();
+                        issuerCertificate.setCertificate(issuer.getEncoded());
+                        issuerCertificate.setSubject(issuer.getSubjectDN().getName());
+                        certificateChain.add(issuerCertificate);
+                        break;
+                    }
                 }
             }
         } catch (Exception e) {
             logger.warn(e.getMessage());
-            certificate = null;
+            signerCertificate = null;
         }
 
-        if (certificate == null)
+        if (signerCertificate == null)
             throw new IllegalStateException("Unable to verify signature.");
 
-        return certificate;
+        return certificateChain;
     }
 }

--- a/src/main/java/no/difi/asic/extras/CmsEncryptedAsicReader.java
+++ b/src/main/java/no/difi/asic/extras/CmsEncryptedAsicReader.java
@@ -3,6 +3,7 @@ package no.difi.asic.extras;
 import com.google.common.io.ByteStreams;
 import no.difi.asic.AsicReader;
 import no.difi.commons.asic.jaxb.asic.AsicManifest;
+import no.difi.commons.asic.jaxb.asic.Certificate;
 import org.bouncycastle.cms.CMSEnvelopedDataParser;
 import org.bouncycastle.cms.RecipientInformation;
 import org.bouncycastle.cms.jcajce.JceKeyTransEnvelopedRecipient;
@@ -12,6 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.PrivateKey;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Wrapper to seamlessly decode encoded files.
@@ -98,5 +100,10 @@ public class CmsEncryptedAsicReader extends CmsEncryptedAsicAbstract implements 
             asicManifest.setRootfile(rootfile.substring(0, rootfile.length() - 4));
 
         return asicManifest;
+    }
+
+    @Override
+    public List<Certificate> getCertificateChain() {
+        return asicReader.getCertificateChain();
     }
 }


### PR DESCRIPTION
This change allows a reader to extract the certificate chain form the signature, allowing for their validation. The chain is built in order and includes the certificate responsible for the signing itself. This should allow for maximum flexibility when choosing whether to validate a signature. 
The changes should not disturb existing functionality or implementations and should be minimally invasive. 