### PR TITLE
Replaced Files#probeContentType with Tika#detect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,12 @@
             <version>30.1.1-jre</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+            <version>2.1.0</version>
+        </dependency>
+
         <!-- TestNG testing framework -->
         <dependency>
             <groupId>org.testng</groupId>


### PR DESCRIPTION
Vi har opplevd problemer med AsicUtils#detectMime i Java 11 når koden kjøres i Docker i k8s (GKE). Konteksten er dette repoet til Fiks IO
https://github.com/ks-no/fiks-io-klient-java

I SSB har vi løst problemet midlertidig ved å endre AsicUtils#detectMime til å benytte Apache Tika, og har puttet artifakten i Nexus lokalt. Disse endringene er med i denne PRen.

MVH Roar Skinderviken, konsulent team-barn, SSB