### PR TITLE
Update CadesAsicManifest.java

### DIFF
--- a/src/main/java/no/difi/asic/CadesAsicManifest.java
+++ b/src/main/java/no/difi/asic/CadesAsicManifest.java
@@ -22,7 +22,7 @@ class CadesAsicManifest extends AbstractAsicManifest {
 
     static {
         try {
-            jaxbContext = JAXBContext.newInstance(ASiCManifestType.class);
+            jaxbContext = JAXBContext.newInstance("no.difi.commons.asic.jaxb.cades");
         } catch (JAXBException e) {
             throw new IllegalStateException(String.format("Unable to create JAXBContext: %s ", e.getMessage()), e);
         }


### PR DESCRIPTION
Hi, 
In a IBM WebSphere Application Server WAS 9 context with the internal JAXB libs, it seems there is a problem to use class name only for unmarshall.
javax.xml.bind.UnmarshalException: Unexpected element "{http://uri.etsi.org/2918/v1.2.1}ASiCManifestType". Expected elements are "".

After trying some modifications, we found that the usage of the package name instead the "ASiCManifestType.class" can help and the unmarshall works now with this modification.

The help was found after reading this post for a similar unmarshall problem: 
https://stackoverflow.com/questions/19262393/how-to-resolve-unmarshalling-exception

Have fun ;)