### PR TITLE
Make CmsEncryptedAsicWriter return self to allow proper chain calling

### DIFF
--- a/src/main/java/no/difi/asic/extras/CmsEncryptedAsicWriter.java
+++ b/src/main/java/no/difi/asic/extras/CmsEncryptedAsicWriter.java
@@ -52,7 +52,7 @@ public class CmsEncryptedAsicWriter extends CmsEncryptedAsicAbstract implements 
      * {@inheritDoc}
      */
     @Override
-    public AsicWriter add(File file) throws IOException {
+    public CmsEncryptedAsicWriter add(File file) throws IOException {
         return add(file.toPath());
     }
 
@@ -60,7 +60,7 @@ public class CmsEncryptedAsicWriter extends CmsEncryptedAsicAbstract implements 
      * {@inheritDoc}
      */
     @Override
-    public AsicWriter add(File file, String entryName) throws IOException {
+    public CmsEncryptedAsicWriter add(File file, String entryName) throws IOException {
         return add(file.toPath(), entryName);
     }
 
@@ -68,7 +68,7 @@ public class CmsEncryptedAsicWriter extends CmsEncryptedAsicAbstract implements 
      * {@inheritDoc}
      */
     @Override
-    public AsicWriter add(Path path) throws IOException {
+    public CmsEncryptedAsicWriter add(Path path) throws IOException {
         return add(path, path.toFile().getName());
     }
 
@@ -76,7 +76,7 @@ public class CmsEncryptedAsicWriter extends CmsEncryptedAsicAbstract implements 
      * {@inheritDoc}
      */
     @Override
-    public AsicWriter add(Path path, String entryName) throws IOException {
+    public CmsEncryptedAsicWriter add(Path path, String entryName) throws IOException {
         try (InputStream inputStream = Files.newInputStream(path)) {
             add(inputStream, entryName);
         }
@@ -87,7 +87,7 @@ public class CmsEncryptedAsicWriter extends CmsEncryptedAsicAbstract implements 
      * {@inheritDoc}
      */
     @Override
-    public AsicWriter add(InputStream inputStream, String filename) throws IOException {
+    public CmsEncryptedAsicWriter add(InputStream inputStream, String filename) throws IOException {
         return add(inputStream, filename, AsicUtils.detectMime(filename));
     }
 
@@ -95,7 +95,7 @@ public class CmsEncryptedAsicWriter extends CmsEncryptedAsicAbstract implements 
      * {@inheritDoc}
      */
     @Override
-    public AsicWriter add(File file, String entryName, MimeType mimeType) throws IOException {
+    public CmsEncryptedAsicWriter add(File file, String entryName, MimeType mimeType) throws IOException {
         return add(file.toPath(), entryName, mimeType);
     }
 
@@ -103,7 +103,7 @@ public class CmsEncryptedAsicWriter extends CmsEncryptedAsicAbstract implements 
      * {@inheritDoc}
      */
     @Override
-    public AsicWriter add(Path path, String entryName, MimeType mimeType) throws IOException {
+    public CmsEncryptedAsicWriter add(Path path, String entryName, MimeType mimeType) throws IOException {
         try (InputStream inputStream = Files.newInputStream(path)) {
             add(inputStream, entryName, mimeType);
         }
@@ -114,45 +114,46 @@ public class CmsEncryptedAsicWriter extends CmsEncryptedAsicAbstract implements 
      * {@inheritDoc}
      */
     @Override
-    public AsicWriter add(InputStream inputStream, String filename, MimeType mimeType) throws IOException {
-        return asicWriter.add(inputStream, filename, mimeType);
+    public CmsEncryptedAsicWriter add(InputStream inputStream, String filename, MimeType mimeType) throws IOException {
+        asicWriter.add(inputStream, filename, mimeType);
+        return this;
     }
 
-    public AsicWriter addEncrypted(File file) throws IOException {
+    public CmsEncryptedAsicWriter addEncrypted(File file) throws IOException {
         return addEncrypted(file.toPath());
     }
 
-    public AsicWriter addEncrypted(File file, String entryName) throws IOException {
+    public CmsEncryptedAsicWriter addEncrypted(File file, String entryName) throws IOException {
         return addEncrypted(file.toPath(), entryName);
     }
 
-    public AsicWriter addEncrypted(Path path) throws IOException {
+    public CmsEncryptedAsicWriter addEncrypted(Path path) throws IOException {
         return addEncrypted(path, path.toFile().getName());
     }
 
-    public AsicWriter addEncrypted(Path path, String entryName) throws IOException {
+    public CmsEncryptedAsicWriter addEncrypted(Path path, String entryName) throws IOException {
         try (InputStream inputStream = Files.newInputStream(path)) {
             addEncrypted(inputStream, entryName);
         }
         return this;
     }
 
-    public AsicWriter addEncrypted(InputStream inputStream, String filename) throws IOException {
+    public CmsEncryptedAsicWriter addEncrypted(InputStream inputStream, String filename) throws IOException {
         return addEncrypted(inputStream, filename, AsicUtils.detectMime(filename));
     }
 
-    public AsicWriter addEncrypted(File file, String entryName, MimeType mimeType) throws IOException {
+    public CmsEncryptedAsicWriter addEncrypted(File file, String entryName, MimeType mimeType) throws IOException {
         return addEncrypted(file.toPath(), entryName, mimeType);
     }
 
-    public AsicWriter addEncrypted(Path path, String entryName, MimeType mimeType) throws IOException {
+    public CmsEncryptedAsicWriter addEncrypted(Path path, String entryName, MimeType mimeType) throws IOException {
         try (InputStream inputStream = Files.newInputStream(path)) {
             addEncrypted(inputStream, entryName, mimeType);
         }
         return this;
     }
 
-    public AsicWriter addEncrypted(InputStream inputStream, String filename, MimeType mimeType) throws IOException {
+    public CmsEncryptedAsicWriter addEncrypted(InputStream inputStream, String filename, MimeType mimeType) throws IOException {
         try {
             ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
             ByteStreams.copy(inputStream, byteArrayOutputStream);
@@ -166,37 +167,43 @@ public class CmsEncryptedAsicWriter extends CmsEncryptedAsicAbstract implements 
 
             this.entryNeames.add(filename);
 
-            return asicWriter.add(new ByteArrayInputStream(data.getEncoded()), filename + ".p7m", mimeType);
+            asicWriter.add(new ByteArrayInputStream(data.getEncoded()), filename + ".p7m", mimeType);
+            return this;
         } catch (Exception e) {
             throw new IOException(e.getMessage(), e);
         }
     }
 
     @Override
-    public AsicWriter setRootEntryName(String name) {
+    public CmsEncryptedAsicWriter setRootEntryName(String name) {
         if (this.entryNeames.contains(name))
             name = String.format("%s.p7m", name);
 
-        return asicWriter.setRootEntryName(name);
+        asicWriter.setRootEntryName(name);
+        return this;
     }
 
     @Override
-    public AsicWriter sign(File keyStoreFile, String keyStorePassword, String keyPassword) throws IOException {
-        return asicWriter.sign(keyStoreFile, keyStorePassword, keyPassword);
+    public CmsEncryptedAsicWriter sign(File keyStoreFile, String keyStorePassword, String keyPassword) throws IOException {
+        asicWriter.sign(keyStoreFile, keyStorePassword, keyPassword);
+        return this;
     }
 
     @Override
-    public AsicWriter sign(File keyStoreFile, String keyStorePassword, String keyAlias, String keyPassword) throws IOException {
-        return asicWriter.sign(keyStoreFile, keyStorePassword, keyAlias, keyPassword);
+    public CmsEncryptedAsicWriter sign(File keyStoreFile, String keyStorePassword, String keyAlias, String keyPassword) throws IOException {
+        asicWriter.sign(keyStoreFile, keyStorePassword, keyAlias, keyPassword);
+        return this;
     }
 
     @Override
-    public AsicWriter sign(SignatureHelper signatureHelper) throws IOException {
-        return asicWriter.sign(signatureHelper);
+    public CmsEncryptedAsicWriter sign(SignatureHelper signatureHelper) throws IOException {
+        asicWriter.sign(signatureHelper);
+        return this;
     }
 
     @Override
-    public AsicWriter sign (File keyStoreFile, String keyStorePassword, KeyStoreType keyStoreType, String keyAlias, String keyPassword) throws IOException {
-        return asicWriter.sign(keyStoreFile, keyStorePassword, keyStoreType, keyAlias, keyPassword);
+    public CmsEncryptedAsicWriter sign (File keyStoreFile, String keyStorePassword, KeyStoreType keyStoreType, String keyAlias, String keyPassword) throws IOException {
+        asicWriter.sign(keyStoreFile, keyStorePassword, keyStoreType, keyAlias, keyPassword);
+        return this;
     }
 }

--- a/src/test/java/no/difi/asic/extras/CmsEncryptedAsicTest.java
+++ b/src/test/java/no/difi/asic/extras/CmsEncryptedAsicTest.java
@@ -93,6 +93,71 @@ public class CmsEncryptedAsicTest {
 
     }
 
+    @Test
+    public void chainCalls() throws Exception {
+
+        // WRITE TO ASIC
+        KeyStore keyStore = loadKeyStore();
+
+        // Fetching certificate
+        X509Certificate certificate = (X509Certificate) keyStore.getCertificate("selfsigned");
+
+        // Store result in ByteArrayOutputStream
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+
+        // Create a new ASiC archive
+        AsicWriter asicWriter = AsicWriterFactory.newFactory().newContainer(byteArrayOutputStream);
+        // Encapsulate ASiC archive to enable writing encrypted content
+        new CmsEncryptedAsicWriter(asicWriter, certificate, CMSAlgorithm.AES128_GCM)
+                .add(getClass().getResourceAsStream("/image.bmp"), "simple.bmp", MimeType.forString("image/bmp"))
+                .addEncrypted(getClass().getResourceAsStream("/image.bmp"), "encrypted.bmp", MimeType.forString("image/bmp"))
+                .setRootEntryName("encrypted.bmp")
+                .sign(new SignatureHelper(getClass().getResourceAsStream("/keystore.jks"), "changeit", "selfsigned", "changeit"));
+        // ByteArrayOutputStream now contains a signed ASiC archive containing one encrypted file
+
+
+        // READ FROM ASIC
+
+        // Fetch private key from keystore
+        PrivateKey privateKey = (PrivateKey) keyStore.getKey("selfsigned", "changeit".toCharArray());
+
+        // Open content of ByteArrayOutputStream for reading
+        AsicReader asicReader = AsicReaderFactory.newFactory().open(new ByteArrayInputStream(byteArrayOutputStream.toByteArray()));
+        // Encapsulate ASiC archive to enable reading encrypted content
+        CmsEncryptedAsicReader reader = new CmsEncryptedAsicReader(asicReader, privateKey);
+
+        // Read plain file
+        Assert.assertEquals(reader.getNextFile(), "simple.bmp");
+        ByteArrayOutputStream file1 = new ByteArrayOutputStream();
+        reader.writeFile(file1);
+
+        // Read encrypted file
+        Assert.assertEquals(reader.getNextFile(), "encrypted.bmp");
+        ByteArrayOutputStream file2 = new ByteArrayOutputStream();
+        reader.writeFile(file2);
+
+        // Verify both files contain the same data
+        Assert.assertEquals(file2.toByteArray(), file1.toByteArray());
+
+        // Verify no more files are found
+        Assert.assertNull(reader.getNextFile());
+
+        // Verify certificate used for signing of ASiC is the same as the one used for signing
+        Assert.assertEquals(reader.getAsicManifest().getCertificate().get(0).getCertificate(), certificate.getEncoded());
+
+        Assert.assertEquals(reader.getAsicManifest().getRootfile(), "encrypted.bmp");
+
+        asicReader.close();
+
+        // Writes the ASiC file to temporary directory
+        File sample = File.createTempFile("sample", ".asice");
+        try (FileOutputStream fileOutputStream = new FileOutputStream(sample)) {
+            fileOutputStream.write(byteArrayOutputStream.toByteArray());
+        }
+        System.out.println("Wrote sample ASiC to " + sample);
+
+    }
+
     private KeyStore loadKeyStore() throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException {
         // Read JKS
         KeyStore keyStore = KeyStore.getInstance("JKS");


### PR DESCRIPTION
- It was impossible to use add().addEncrypted()
- addEncrypted(InputStream inputStream, String filename, MimeType mimeType) was returning
the underlying AsicWriter thus sebsequent calls could end up to a different implementation
e.g. in addEncrypted(InputStream, String, MimeType).setRootEntryName(String)
setRootEntryName ended up directly calling the underlying asicWriter and not CmsEncryptedAsicWriter