### PR TITLE
upgrade library

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@
 
 # Associated Signature Container (ASiC)
 
-An ASiC file is simply a ZIP archive created according to some rules set forth in the specifications. 
+An ASiC file is simply a ZIP archive created according to some rules set forth in the specifications.
 
 The benefits of using containers for message transfer are:
+
 * all files are kept together as a single collection.
 * very efficient with regards to space.
 * due to the compressed format, communication bandwith is utilized better
@@ -18,21 +19,20 @@ This component provides an easy-to-use factory for creating ASiC-E containers.
 Conformance is claimed according to 7.2.1 (TBA) and 7.2.2 in
 [ETSI TS 102 918 V1.3.1](http://webapp.etsi.org/workprogram/Report_WorkItem.asp?WKI_ID=42455).
 
-
 ## Maven
 
 ```xml
+
 <dependency>
-	<groupId>no.difi.commons</groupId>
-	<artifactId>commons-asic</artifactId>
-	<version>[newest version]</version>
+    <groupId>no.difi.commons</groupId>
+    <artifactId>commons-asic</artifactId>
+    <version>0.12</version>
 </dependency>
 ```
 
-
 ## What does it look like?
 
-In general the archive looks something like depicted below 
+In general the archive looks something like depicted below
 
 ```
 asic-container.asice: 
@@ -53,48 +53,49 @@ asic-container.asice:
 
 Consult the [AsicCadesContainerWriterTest](src/test/java/no/difi/asic/AsicWriterTest.java) for sample usage.
 Here is a rough sketch on how to do it:
+
 ```java
 // Creates an ASiC archive after which every entry is read back from the archive.
 
 // Name of the file to hold the ASiC archive
-File archiveOutputFile = new File(System.getProperty("java.io.tmpdir"), "asic-sample-default.zip");
+File archiveOutputFile=new File(System.getProperty("java.io.tmpdir"),"asic-sample-default.zip");
 
 // Creates an AsicWriterFactory with default signature method
-AsicWriterFactory asicWriterFactory = AsicWriterFactory.newFactory();
+        AsicWriterFactory asicWriterFactory=AsicWriterFactory.newFactory();
 
 // the following variables are needed:
 // keyStore, keyStorePassword, keyAlias, privateKeyPassword
 
 // Creates the actual container with all the data objects (files) and signs it.
-AsicWriter asicWriter = asicWriterFactory.newContainer(archiveOutputFile)
+        AsicWriter asicWriter=asicWriterFactory.newContainer(archiveOutputFile)
         // Adds an ordinary file, using the file name as the entry name
         .add(biiEnvelopeFile)
-                // Adds another file, explicitly naming the entry and specifying the MIME type
-        .add(biiMessageFile, BII_MESSAGE_XML, MimeType.forString("application/xml"))
-                // Signing the contents of the archive, closes it for further changes.
-        .sign(keyStore, keyStorePassword, keyAlias, privateKeyPassword);
+        // Adds another file, explicitly naming the entry and specifying the MIME type
+        .add(biiMessageFile,BII_MESSAGE_XML,MimeType.forString("application/xml"))
+        // Signing the contents of the archive, closes it for further changes.
+        .sign(keyStore,keyStorePassword,keyAlias,privateKeyPassword);
 
 // Opens the generated archive and reads each entry
-AsicReader asicReader = AsicReaderFactory.newFactory().open(archiveOutputFile);
+        AsicReader asicReader=AsicReaderFactory.newFactory().open(archiveOutputFile);
 
-String entryName;
+        String entryName;
 
 // Iterates over each entry and writes the contents into a file having same name as the entry
-while ((entryName = asicReader.getNextFile()) != null) {
-    log.debug("Read entry " + entryName);
-    
-    // Creates file with same name as entry
-    File file = new File(entryName);
-    // Ensures we don't overwrite anything
-    if (file.exists()) {
+        while((entryName=asicReader.getNextFile())!=null){
+        log.debug("Read entry "+entryName);
+
+        // Creates file with same name as entry
+        File file=new File(entryName);
+        // Ensures we don't overwrite anything
+        if(file.exists()){
         throw new IllegalStateException("File already exists");
-    }
-    asicReader.writeFile(file);
-    
-    // Removes file immediately, since this is just a test 
-    file.delete();  
-}
-asicReader.close(); 
+        }
+        asicReader.writeFile(file);
+
+        // Removes file immediately, since this is just a test 
+        file.delete();
+        }
+        asicReader.close(); 
 ```
 
 ## Creating an encoded container
@@ -104,51 +105,50 @@ If you want to CMS-encode the container in memory as a byte stream this can be d
 
 ```java
 // create a byte stream to hold the data
-ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+ByteArrayOutputStream byteArrayOutputStream=new ByteArrayOutputStream();
 
 // create an asic writer
-AsicWriter asicWriter = AsicWriterFactory.newFactory().newContainer(byteArrayOutputStream);
+        AsicWriter asicWriter=AsicWriterFactory.newFactory().newContainer(byteArrayOutputStream);
 
 
 // get the certificate of the recipient
-X509Certificate recipientCertificate = ...
+        X509Certificate recipientCertificate=...
 
 // create an encoded writer for the given recipient
-CmsEncryptedAsicWriter writer = new CmsEncryptedAsicWriter(asicWriter, recipientCertificate);
+        CmsEncryptedAsicWriter writer=new CmsEncryptedAsicWriter(asicWriter,recipientCertificate);
 
 
 // add a "file" from another byte stream to the container
-String message = ...
-String fileName = ...
-InputStream fileStream = new ByteArrayInputStream(message.getBytes(StandardCharsets.UTF_8));
+        String message=...
+        String fileName=...
+        InputStream fileStream=new ByteArrayInputStream(message.getBytes(StandardCharsets.UTF_8));
 
-writer.addEncrypted(fileStream, fileName);
+        writer.addEncrypted(fileStream,fileName);
 
 // set the root file if there is a root / major file and the rest are attachments
-writer.setRootEntryName(fileName);
+        writer.setRootEntryName(fileName);
 
 // the following variables are needed:
 // keyStore, keyStorePassword, keyAlias, privateKeyPassword
-writer.sign(new SignatureHelper(keyStore, keyStorePassword, keyAlias, privateKeyPassword));
+        writer.sign(new SignatureHelper(keyStore,keyStorePassword,keyAlias,privateKeyPassword));
 ```
 
 To read such an encrypted container:
 
 ```java
-AsicReader asicReader = AsicReaderFactory.newFactory().open(asicContainerByteArrayInputStream);
- 
-PrivateKey receiverPrivateKey = ...
- 
-CmsEncryptedAsicReader reader = new CmsEncryptedAsicReader(asicReader, receiverPrivateKey);
+AsicReader asicReader=AsicReaderFactory.newFactory().open(asicContainerByteArrayInputStream);
+
+        PrivateKey receiverPrivateKey=...
+
+        CmsEncryptedAsicReader reader=new CmsEncryptedAsicReader(asicReader,receiverPrivateKey);
 ```
 
-From here on you have a "normal" reader an can continue like seen above. 
+From here on you have a "normal" reader an can continue like seen above.
 
 ## Security
 
 This library validate signatures, but does not validate the certificate. It's up to the implementer using the library
 to choose if and how to validate certificates. Certificate(s) used for validation is exposed by the library.
-
 
 ## Creating an ASiC-E container manually
 
@@ -158,13 +158,16 @@ This is how you create an ASiC container manually:
 1. Copy the files `bii-envelope.xml`and `bii-trns081.xml` into `asic-sample`
 1. Create the directory `META-INF`:
 1. Compute the SHA-256 digest value for the files and save them:
+
 ```
 openssl dgst -sha256 -binary bii-envelope |base64
 openssl dgst -sha256 -binary bii-message |base64
 
 ```
+
 1. Create the file `META-INF/asicmanifest.xml`, add an entry for each file and
-paste the SHA-256 values computed in the previous step. The file should look something like this:
+   paste the SHA-256 values computed in the previous step. The file should look something like this:
+
 ```xml
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <ASiCManifest xmlns="http://uri.etsi.org/02918/v1.2.1#" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#">
@@ -179,23 +182,28 @@ paste the SHA-256 values computed in the previous step. The file should look som
     </DataObjectReference>
 </ASiCManifest>
 ```
+
 1. Create the signature, which should be placed into `signature.p7s`. The file `comodo.pem` should
-be replaced with the PEM-file holding your private key for the signature, and the certificate to prove it.
+   be replaced with the PEM-file holding your private key for the signature, and the certificate to prove it.
+
 ```
 openssl cms -sign -in META-INF/asicmanifest.xml -binary -outform der -out META-INF/signature.p7s -signer comodo.pem
 ```
 
 1. Verify the signature:
+
 ```
 openssl cms -verify -in META-INF/signature.p7s -inform der -content META-INF/asicmanifest.xml -noverify
 ```
-Note! The `-noverify` option omits verifying the certificate chain of trust and should only be used to verify that the files were created properly
+
+Note! The `-noverify` option omits verifying the certificate chain of trust and should only be used to verify that the
+files were created properly
 
 1. Create the ZIP-archive using your favourite tool :-)
 
-**Disclaimer:** The procedure liste above works on a Mac or Linux machine with the various tools pre-installed. If you are running on a windows machine
+**Disclaimer:** The procedure liste above works on a Mac or Linux machine with the various tools pre-installed. If you
+are running on a windows machine
 you need to download and install the *openssl* and *base64* tool and adapt the procedure according to your liking.
-
 
 ## Verifying the contents using *openssl*
 
@@ -207,16 +215,18 @@ openssl cms -verify -in META-INF/signature.p7s -inform der -content META-INF/asi
 
 The `-noverify` option will allow self signed certificates, and should normally be omitted :-).
 
-
 ## Programmers notes
 
 You might encounter memory problems when using Java 1.7. This is due to the memory consumption of JAXB.
 
 Try this before you run maven, you might need to increase this even further (your mileage may vary):
+
 ```
 export MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=512m"
 ```
+
 or on Windows:
+
 ```
 set MAVEN_OPTS=-Xmx1024m -XX:MaxPermSize=512m
 ```

--- a/README.md
+++ b/README.md
@@ -61,41 +61,41 @@ Here is a rough sketch on how to do it:
 File archiveOutputFile=new File(System.getProperty("java.io.tmpdir"),"asic-sample-default.zip");
 
 // Creates an AsicWriterFactory with default signature method
-        AsicWriterFactory asicWriterFactory=AsicWriterFactory.newFactory();
+AsicWriterFactory asicWriterFactory = AsicWriterFactory.newFactory();
 
 // the following variables are needed:
 // keyStore, keyStorePassword, keyAlias, privateKeyPassword
 
 // Creates the actual container with all the data objects (files) and signs it.
-        AsicWriter asicWriter=asicWriterFactory.newContainer(archiveOutputFile)
-        // Adds an ordinary file, using the file name as the entry name
-        .add(biiEnvelopeFile)
-        // Adds another file, explicitly naming the entry and specifying the MIME type
-        .add(biiMessageFile,BII_MESSAGE_XML,MimeType.forString("application/xml"))
-        // Signing the contents of the archive, closes it for further changes.
-        .sign(keyStore,keyStorePassword,keyAlias,privateKeyPassword);
+AsicWriter asicWriter = asicWriterFactory.newContainer(archiveOutputFile)
+    // Adds an ordinary file, using the file name as the entry name
+    .add(biiEnvelopeFile)
+    // Adds another file, explicitly naming the entry and specifying the MIME type
+    .add(biiMessageFile,BII_MESSAGE_XML,MimeType.forString("application/xml"))
+    // Signing the contents of the archive, closes it for further changes.
+    .sign(keyStore,keyStorePassword,keyAlias,privateKeyPassword);
 
 // Opens the generated archive and reads each entry
-        AsicReader asicReader=AsicReaderFactory.newFactory().open(archiveOutputFile);
+AsicReader asicReader = AsicReaderFactory.newFactory().open(archiveOutputFile);
 
-        String entryName;
+String entryName;
 
 // Iterates over each entry and writes the contents into a file having same name as the entry
-        while((entryName=asicReader.getNextFile())!=null){
-        log.debug("Read entry "+entryName);
-
-        // Creates file with same name as entry
-        File file=new File(entryName);
-        // Ensures we don't overwrite anything
-        if(file.exists()){
+while((entryName = asicReader.getNextFile()) != null){
+    log.debug("Read entry "+entryName);
+    
+    // Creates file with same name as entry
+    File file = new File(entryName);
+    // Ensures we don't overwrite anything
+    if(file.exists()){
         throw new IllegalStateException("File already exists");
-        }
-        asicReader.writeFile(file);
-
-        // Removes file immediately, since this is just a test 
-        file.delete();
-        }
-        asicReader.close(); 
+    }
+    asicReader.writeFile(file);
+    
+    // Removes file immediately, since this is just a test 
+    file.delete();
+}
+asicReader.close(); 
 ```
 
 ## Creating an encoded container
@@ -108,39 +108,39 @@ If you want to CMS-encode the container in memory as a byte stream this can be d
 ByteArrayOutputStream byteArrayOutputStream=new ByteArrayOutputStream();
 
 // create an asic writer
-        AsicWriter asicWriter=AsicWriterFactory.newFactory().newContainer(byteArrayOutputStream);
+AsicWriter asicWriter = AsicWriterFactory.newFactory().newContainer(byteArrayOutputStream);
 
 
 // get the certificate of the recipient
-        X509Certificate recipientCertificate=...
+X509Certificate recipientCertificate =...
 
 // create an encoded writer for the given recipient
-        CmsEncryptedAsicWriter writer=new CmsEncryptedAsicWriter(asicWriter,recipientCertificate);
+CmsEncryptedAsicWriter writer  =new CmsEncryptedAsicWriter(asicWriter,recipientCertificate);
 
 
 // add a "file" from another byte stream to the container
-        String message=...
-        String fileName=...
-        InputStream fileStream=new ByteArrayInputStream(message.getBytes(StandardCharsets.UTF_8));
+String message = ...
+String fileName = ...
+InputStream fileStream = new ByteArrayInputStream(message.getBytes(StandardCharsets.UTF_8));
 
-        writer.addEncrypted(fileStream,fileName);
+writer.addEncrypted(fileStream,fileName);
 
 // set the root file if there is a root / major file and the rest are attachments
-        writer.setRootEntryName(fileName);
+writer.setRootEntryName(fileName);
 
 // the following variables are needed:
 // keyStore, keyStorePassword, keyAlias, privateKeyPassword
-        writer.sign(new SignatureHelper(keyStore,keyStorePassword,keyAlias,privateKeyPassword));
+writer.sign(new SignatureHelper(keyStore,keyStorePassword,keyAlias,privateKeyPassword));
 ```
 
 To read such an encrypted container:
 
 ```java
-AsicReader asicReader=AsicReaderFactory.newFactory().open(asicContainerByteArrayInputStream);
+AsicReader asicReader = AsicReaderFactory.newFactory().open(asicContainerByteArrayInputStream);
 
-        PrivateKey receiverPrivateKey=...
+PrivateKey receiverPrivateKey = ...
 
-        CmsEncryptedAsicReader reader=new CmsEncryptedAsicReader(asicReader,receiverPrivateKey);
+CmsEncryptedAsicReader reader = new CmsEncryptedAsicReader(asicReader,receiverPrivateKey);
 ```
 
 From here on you have a "normal" reader an can continue like seen above.

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
     <properties>
         <java.encoding>UTF-8</java.encoding>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
     </properties>
 
     <dependencies>
@@ -56,12 +56,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.32</version>
+            <version>2.0.6</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.6</version>
+            <version>1.4.5</version>
             <scope>test</scope>
         </dependency>
 
@@ -77,22 +77,34 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.69</version>
+            <version>1.70</version>
         </dependency>
 
         <!-- Google -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>30.1.1-jre</version>
+            <version>31.1-jre</version>
         </dependency>
 
         <!-- TestNG testing framework -->
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.4.0</version>
+            <version>7.7.1</version>
             <scope>test</scope>
+        </dependency>
+
+        <!--         needed for xjc generated classes -->
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>4.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>4.0.0</version>
         </dependency>
 
     </dependencies>
@@ -112,7 +124,7 @@
                 <!-- Explicitly declares which version of Java to use -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.11.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -122,7 +134,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.3.0</version>
                 <configuration>
                     <encoding>${java.encoding}</encoding>
                 </configuration>
@@ -138,23 +150,27 @@
                 </configuration>
             </plugin>
             <plugin>
-                <!-- JAXB plugin generates Java classes corresponding to the XML Schema Definitions found in this project -->
-                <!-- See  https://github.com/highsource/maven-jaxb2-plugin -->
-                <!-- Documentation at https://github.com/highsource/maven-jaxb2-plugin/wiki -->
-                <groupId>org.jvnet.jaxb2.maven2</groupId>
-                <artifactId>maven-jaxb2-plugin</artifactId>
-                <version>0.14.0</version>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>jaxb2-maven-plugin</artifactId>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>xsd</id>
                         <goals>
-                            <goal>generate</goal>
+                            <goal>xjc</goal>
                         </goals>
                         <configuration>
-                            <schemaDirectory>src/main/xsd</schemaDirectory>
-                            <bindingDirectory>src/main/xjb</bindingDirectory>
-                            <!-- If you want to generate the classes into a different directory than the default, this is how you do it. -->
-                            <!-- <generateDirectory>${project.build.directory}/generated-sources/xjc-xsd</generateDirectory> -->
+                            <sources>
+                                <source>
+                                    src/main/xsd
+                                </source>
+                            </sources>
+                            <xjbSources>
+                                <xjbSource>
+                                    src/main/xjb
+                                </xjbSource>
+                            </xjbSources>
+                            <locale>en</locale>
                         </configuration>
                     </execution>
                 </executions>
@@ -162,7 +178,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>
-                <version>1.0.0</version>
+                <version>1.1.0</version>
                 <executions>
                     <execution>
                         <id>set-additional-system-properties</id>
@@ -172,7 +188,7 @@
                         <configuration>
                             <properties>
                                 <property>
-                                    <name>javax.xml.accessExternalSchema</name>
+                                    <name>javax.xml.accessExternalDTD</name>
                                     <value>all</value>
                                 </property>
                             </properties>
@@ -183,7 +199,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.7</version>
+                <version>0.8.8</version>
                 <executions>
                     <execution>
                         <goals>
@@ -215,13 +231,13 @@
                         <dependency>
                             <groupId>org.apache.maven.scm</groupId>
                             <artifactId>maven-scm-provider-gitexe</artifactId>
-                            <version>1.9.4</version>
+                            <version>1.13.0</version>
                         </dependency>
                     </dependencies>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.5.0</version>
                     <executions>
                         <execution>
                             <id>package-javadoc</id>
@@ -253,7 +269,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -278,7 +294,7 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.3.0</version>
+                        <version>3.5.0</version>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,11 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>no.difi.commons</groupId>
     <artifactId>commons-asic</artifactId>
-    <version>0.12.0-SNAPSHOT</version>
+    <version>0.12</version>
     <packaging>jar</packaging>
 
     <name>Associated Signature Container (ASiC)</name>

--- a/src/main/java/no/difi/asic/CadesAsicManifest.java
+++ b/src/main/java/no/difi/asic/CadesAsicManifest.java
@@ -9,7 +9,7 @@ import org.bouncycastle.util.encoders.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.bind.*;
+import jakarta.xml.bind.*;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 

--- a/src/main/java/no/difi/asic/CreateXadesArtifacts.java
+++ b/src/main/java/no/difi/asic/CreateXadesArtifacts.java
@@ -9,8 +9,8 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
@@ -48,7 +48,7 @@ public class CreateXadesArtifacts {
         certificateDigest.setDigestValue(certificateDigestValue);
 
         X509IssuerSerialType certificateIssuer = new X509IssuerSerialType();
-        certificateIssuer.setX509IssuerName(certificate.getIssuerDN().getName());
+        certificateIssuer.setX509IssuerName(certificate.getIssuerX500Principal().getName());
         certificateIssuer.setX509SerialNumber(certificate.getSerialNumber());
 
         CertIDType certID = new CertIDType();

--- a/src/main/java/no/difi/asic/OasisManifest.java
+++ b/src/main/java/no/difi/asic/OasisManifest.java
@@ -3,10 +3,10 @@ package no.difi.asic;
 import no.difi.commons.asic.jaxb.opendocument.manifest.FileEntry;
 import no.difi.commons.asic.jaxb.opendocument.manifest.Manifest;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 

--- a/src/main/java/no/difi/asic/XadesAsicManifest.java
+++ b/src/main/java/no/difi/asic/XadesAsicManifest.java
@@ -1,5 +1,8 @@
 package no.difi.asic;
 
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 import no.difi.commons.asic.jaxb.cades.XAdESSignaturesType;
 import no.difi.commons.asic.jaxb.xades.DataObjectFormatType;
 import no.difi.commons.asic.jaxb.xades.QualifyingPropertiesType;
@@ -11,9 +14,6 @@ import no.difi.commons.asic.jaxb.xmldsig.X509DataType;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.JAXBException;
-import jakarta.xml.bind.Unmarshaller;
 import javax.xml.crypto.MarshalException;
 import javax.xml.crypto.NodeSetData;
 import javax.xml.crypto.URIDereferencer;
@@ -28,7 +28,6 @@ import javax.xml.crypto.dsig.spec.C14NMethodParameterSpec;
 import javax.xml.crypto.dsig.spec.TransformParameterSpec;
 import javax.xml.transform.stream.StreamSource;
 import java.io.ByteArrayInputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
@@ -128,11 +127,7 @@ class XadesAsicManifest extends AbstractAsicManifest {
     }
 
     private String encodeFilename(String filename) {
-        try {
-            return URLEncoder.encode(filename, StandardCharsets.UTF_8.name());
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalStateException(String.format("Could not URL encode filename = '%s'", filename), e);
-        }
+        return URLEncoder.encode(filename, StandardCharsets.UTF_8);
     }
 
     public byte[] toBytes(SignatureHelper signatureHelper) {

--- a/src/main/java/no/difi/asic/XadesAsicManifest.java
+++ b/src/main/java/no/difi/asic/XadesAsicManifest.java
@@ -11,9 +11,9 @@ import no.difi.commons.asic.jaxb.xmldsig.X509DataType;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 import javax.xml.crypto.MarshalException;
 import javax.xml.crypto.NodeSetData;
 import javax.xml.crypto.URIDereferencer;

--- a/src/main/xjb/bindings.xjb
+++ b/src/main/xjb/bindings.xjb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bindings version="2.1"
-          xmlns="http://java.sun.com/xml/ns/jaxb"
+<bindings version="3.0"
+          xmlns="https://jakarta.ee/xml/ns/jaxb"
           xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
           extensionBindingPrefixes="xjc">
 

--- a/src/test/java/no/difi/asic/AsicCadesReferenceTest.java
+++ b/src/test/java/no/difi/asic/AsicCadesReferenceTest.java
@@ -7,8 +7,8 @@ import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Marshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Marshaller;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.security.Security;

--- a/src/test/java/no/difi/asic/AsicManifestReferenceTest.java
+++ b/src/test/java/no/difi/asic/AsicManifestReferenceTest.java
@@ -6,8 +6,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Marshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Marshaller;
 import java.io.ByteArrayOutputStream;
 
 /**


### PR DESCRIPTION
The Library still uses now the new jakarta packages (jakarta.xml.bind) instead of the deprecated javax.xml.bind-packages.
It is possible to upgrade to newest dependencies, thus reducing the risk of security issues.