### PR TITLE
Migrate to Jakarta EE (#1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,22 +46,40 @@
     </licenses>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.encoding>UTF-8</java.encoding>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
     </properties>
 
     <dependencies>
-
+        <!-- Jakarta EE -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>2.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>4.0.1</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- /Jakarta EE -->
         <!-- Logging -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.32</version>
+            <version>2.0.7</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.6</version>
+            <version>1.4.6</version>
             <scope>test</scope>
         </dependency>
 
@@ -76,8 +94,8 @@
         <!-- Bouncy Castle is used for creating and verifying signatures -->
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.69</version>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>1.72</version>
         </dependency>
 
         <!-- Google -->
@@ -112,25 +130,21 @@
                 <!-- Explicitly declares which version of Java to use -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.11.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
-                    <encoding>${java.encoding}</encoding>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.2.0</version>
-                <configuration>
-                    <encoding>${java.encoding}</encoding>
-                </configuration>
+                <version>3.3.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0</version>
                 <configuration>
                     <failIfNoTests>true</failIfNoTests>
                     <!-- Seems this will alleviate the problem of out-of-memory -->
@@ -138,23 +152,25 @@
                 </configuration>
             </plugin>
             <plugin>
-                <!-- JAXB plugin generates Java classes corresponding to the XML Schema Definitions found in this project -->
-                <!-- See  https://github.com/highsource/maven-jaxb2-plugin -->
-                <!-- Documentation at https://github.com/highsource/maven-jaxb2-plugin/wiki -->
-                <groupId>org.jvnet.jaxb2.maven2</groupId>
-                <artifactId>maven-jaxb2-plugin</artifactId>
-                <version>0.14.0</version>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>jaxb2-maven-plugin</artifactId>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>xsd</id>
                         <goals>
-                            <goal>generate</goal>
+                            <goal>xjc</goal>
                         </goals>
+                        <phase>generate-sources</phase>
                         <configuration>
-                            <schemaDirectory>src/main/xsd</schemaDirectory>
-                            <bindingDirectory>src/main/xjb</bindingDirectory>
-                            <!-- If you want to generate the classes into a different directory than the default, this is how you do it. -->
-                            <!-- <generateDirectory>${project.build.directory}/generated-sources/xjc-xsd</generateDirectory> -->
+                            <addGeneratedAnnotation>true</addGeneratedAnnotation>
+                            <verbose>true</verbose>
+                            <sources>
+                                <source>src/main/xsd</source>
+                            </sources>
+                            <xjbSources>
+                                <xjbSource>src/main/xjb</xjbSource>
+                            </xjbSources>
                         </configuration>
                     </execution>
                 </executions>
@@ -183,7 +199,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.7</version>
+                <version>0.8.8</version>
                 <executions>
                     <execution>
                         <goals>
@@ -221,7 +237,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.5.0</version>
                     <executions>
                         <execution>
                             <id>package-javadoc</id>

--- a/src/main/java/no/difi/asic/CadesAsicManifest.java
+++ b/src/main/java/no/difi/asic/CadesAsicManifest.java
@@ -1,5 +1,6 @@
 package no.difi.asic;
 
+import jakarta.xml.bind.*;
 import no.difi.commons.asic.jaxb.cades.ASiCManifestType;
 import no.difi.commons.asic.jaxb.cades.DataObjectReferenceType;
 import no.difi.commons.asic.jaxb.cades.ObjectFactory;
@@ -9,7 +10,6 @@ import org.bouncycastle.util.encoders.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.bind.*;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 

--- a/src/main/java/no/difi/asic/CreateXadesArtifacts.java
+++ b/src/main/java/no/difi/asic/CreateXadesArtifacts.java
@@ -1,6 +1,8 @@
 package no.difi.asic;
 
 import com.google.common.hash.Hashing;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
 import no.difi.commons.asic.jaxb.xades.*;
 import no.difi.commons.asic.jaxb.xmldsig.DigestMethodType;
 import no.difi.commons.asic.jaxb.xmldsig.X509IssuerSerialType;
@@ -9,8 +11,6 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;

--- a/src/main/java/no/difi/asic/OasisManifest.java
+++ b/src/main/java/no/difi/asic/OasisManifest.java
@@ -1,12 +1,12 @@
 package no.difi.asic;
 
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 import no.difi.commons.asic.jaxb.opendocument.manifest.FileEntry;
 import no.difi.commons.asic.jaxb.opendocument.manifest.Manifest;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 

--- a/src/main/java/no/difi/asic/XadesAsicManifest.java
+++ b/src/main/java/no/difi/asic/XadesAsicManifest.java
@@ -1,5 +1,8 @@
 package no.difi.asic;
 
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 import no.difi.commons.asic.jaxb.cades.XAdESSignaturesType;
 import no.difi.commons.asic.jaxb.xades.DataObjectFormatType;
 import no.difi.commons.asic.jaxb.xades.QualifyingPropertiesType;
@@ -11,9 +14,6 @@ import no.difi.commons.asic.jaxb.xmldsig.X509DataType;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
 import javax.xml.crypto.MarshalException;
 import javax.xml.crypto.NodeSetData;
 import javax.xml.crypto.URIDereferencer;

--- a/src/main/xjb/bindings.xjb
+++ b/src/main/xjb/bindings.xjb
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bindings version="2.1"
-          xmlns="http://java.sun.com/xml/ns/jaxb"
+<bindings
+          xmlns="https://jakarta.ee/xml/ns/jaxb"
+          xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
           xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
-          extensionBindingPrefixes="xjc">
+          jaxb:extensionBindingPrefixes="xjc"
+          jaxb:version="3.0"
+>
 
     <bindings schemaLocation="../xsd/asic-model-1.0.xsd">
         <xjc:simple/>

--- a/src/main/xsd/xmldsig-core-schema.xsd
+++ b/src/main/xsd/xmldsig-core-schema.xsd
@@ -1,24 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE schema
-  PUBLIC "-//W3C//DTD XMLSchema 200102//EN" "http://www.w3.org/2001/XMLSchema.dtd"
- [
-   <!ATTLIST schema 
-     xmlns:ds CDATA #FIXED "http://www.w3.org/2000/09/xmldsig#">
-   <!ENTITY dsig 'http://www.w3.org/2000/09/xmldsig#'>
-   <!ENTITY % p ''>
-   <!ENTITY % s ''>
-  ]>
-
-<!--
-Downloaded and imported into this project on July 3, 2015:
-
-  curl -O http://www.w3.org/TR/xmldsig-core/xmldsig-core-schema.xsd
-
--->
-
 <!-- Schema for XML Signatures
     http://www.w3.org/2000/09/xmldsig#
-    $Revision: 1.1 $ on $Date: 2002/02/08 20:32:26 $ by $Author: reagle $
+    $Revision: 1.2 $ on $Date: 2013-04-16 12:48:49 $ by $Author: denis $
 
     Copyright 2001 The Internet Society and W3C (Massachusetts Institute
     of Technology, Institut National de Recherche en Informatique et en
@@ -31,7 +14,10 @@ Downloaded and imported into this project on July 3, 2015:
     [1] http://www.w3.org/Consortium/Legal/copyright-software-19980720
     [2] http://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html#DTD
 -->
-
+<!--
+Downloaded and imported into this project on April 3, 2023:
+  curl -O https://www.w3.org/TR/xmldsig-core/xmldsig-core-schema.xsd
+-->
 
 <schema xmlns="http://www.w3.org/2001/XMLSchema"
         xmlns:ds="http://www.w3.org/2000/09/xmldsig#"

--- a/src/test/java/no/difi/asic/AsicCadesReferenceTest.java
+++ b/src/test/java/no/difi/asic/AsicCadesReferenceTest.java
@@ -7,8 +7,8 @@ import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Marshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Marshaller;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.security.Security;

--- a/src/test/java/no/difi/asic/AsicManifestReferenceTest.java
+++ b/src/test/java/no/difi/asic/AsicManifestReferenceTest.java
@@ -6,8 +6,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Marshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Marshaller;
 import java.io.ByteArrayOutputStream;
 
 /**


### PR DESCRIPTION
In order to upgrade our modules that are using AsicE we need to move from the old javax.xml.binding style of code to Jakarta EE
As we (KS) understand this is a breaking change we are considering maintaining our own fork